### PR TITLE
Don't raise an error when skipping user authentication in the magic links controller

### DIFF
--- a/app/controllers/magic/link/magic_links_controller.rb
+++ b/app/controllers/magic/link/magic_links_controller.rb
@@ -1,7 +1,7 @@
 module Magic
   module Link
     class MagicLinksController < ::ApplicationController
-      skip_before_action :authenticate_user!
+      skip_before_action :authenticate_user!, :raise => false
       before_action :check_user, only: :new
 
       def new


### PR DESCRIPTION
Just adding `:raise => false` to `skip_before_action :authenticate_user!` seems to fix any issues and gets the gem working again.