### PR TITLE
make forced token generating configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Magic::Link.configure do |config|
   config.user_class = "Customer" # Default is User
   config.email_from = "test@yourapp.com"
   config.token_expiration_hours = 6 # Default is 6
+  config.force_new_tokens = false # Default is false
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Magic::Link.configure do |config|
   config.email_from = "test@yourapp.com"
   config.token_expiration_hours = 6 # Default is 6
   config.force_new_tokens = false # Default is false
+  config.force_user_change = false # Default is false, if true it will automatically sign out current user and log in the new one when magic link is used
 end
 ```
 

--- a/app/controllers/magic/link/magic_links_controller.rb
+++ b/app/controllers/magic/link/magic_links_controller.rb
@@ -20,7 +20,7 @@ module Magic
         user  = email && token && Magic::Link.user_class.find_by(email: email)
 
         # TODO: Handle a different user trying to sign in
-        if token && send("#{Magic::Link.user_class.name.underscore}_signed_in?")
+        if !Magic::Link.force_user_change && token && send("#{Magic::Link.user_class.name.underscore}_signed_in?")
           flash[:alert] = "You are already signed in"
           redirect_to main_app.send(Magic::Link.after_sign_in_path)
         elsif user && token_matches?(user) && token_not_expired?(user)

--- a/app/models/magic/link/magic_link.rb
+++ b/app/models/magic/link/magic_link.rb
@@ -20,7 +20,7 @@ module Magic
           MagicLinkMailer.send_magic_link(email, token).deliver_later
         end
 
-        def set_sign_in_token(force: false)
+        def set_sign_in_token(force: Magic::Link.force_new_tokens)
           if user && (force || (user.sign_in_token.blank? || user.sign_in_token_sent_at < Magic::Link.token_expiration_hours.hours.ago))
             raw, enc = Devise.token_generator.generate(Magic::Link.user_class, :sign_in_token)
             user.sign_in_token = enc

--- a/lib/magic/link.rb
+++ b/lib/magic/link.rb
@@ -15,6 +15,9 @@ module Magic
     mattr_accessor :after_sign_in_path
     @@after_sign_in_path = "root_path"
 
+    mattr_accessor :force_new_tokens
+    @@force_new_tokens = false
+
     class << self
       def configure
         yield self

--- a/lib/magic/link.rb
+++ b/lib/magic/link.rb
@@ -18,6 +18,9 @@ module Magic
     mattr_accessor :force_new_tokens
     @@force_new_tokens = false
 
+    mattr_accessor :force_user_change
+    @@force_user_change = false
+
     class << self
       def configure
         yield self

--- a/lib/magic/link/version.rb
+++ b/lib/magic/link/version.rb
@@ -1,5 +1,5 @@
 module Magic
   module Link
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end


### PR DESCRIPTION
I have added a configuration option for the token generator behaviour when a valid token is already in database. There already was the force attribute in generator method which wasn't accessible from anywhere. I made it configurable from initializer and set default value to false for backward compatibility. I also updated README to let users know about the option.